### PR TITLE
修复时区问题

### DIFF
--- a/main.go
+++ b/main.go
@@ -277,7 +277,7 @@ func sendTemplateMessage(accessToken string, params RequestParams) (WechatAPIRes
 	// 处理时区，默认东八区
 	location, err := time.LoadLocation("Asia/Shanghai")
 	if err != nil {
-		location, _ = time.LoadLocation("Asia/Shanghai") // 确保默认使用东八区
+		location = time.FixedZone("CST", 8*60*60) // 确保默认使用东八区
 	}
 
 	// 如果参数中有时区，则尝试使用该时区


### PR DESCRIPTION
在 Windows 下没有时区信息, 无法正确识别 `Asia/Shanghai`, 改用 `FixedZone`

```log
Server is running on： http://127.0.0.1:5566
2026/01/07 11:18:01 http: panic serving 127.0.0.1:64330: time: missing Location in call to Time.In
goroutine 6 [running]:
net/http.(*conn).serve.func1()
        C:/Users/DexterHo/.g/go/src/net/http/server.go:1825 +0xbf
panic({0x710aa0, 0x7e19b0})
        C:/Users/DexterHo/.g/go/src/runtime/panic.go:844 +0x258
time.Time.In(...)
        C:/Users/DexterHo/.g/go/src/time/time.go:1105
main.sendTemplateMessage({0xc00014c240?, 0x0?}, {{0xc00000aca0, 0xe}, {0xc00000ea40, 0x39}, {0xc000016600, 0x12}, {0xc000010280, 0x20}, ...})
        main.go:292 +0xa45
main.handleWxSend({0x7e4ad0?, 0xc0001340e0}, 0xc000140000)
        main.go:205 +0x99f
net/http.HandlerFunc.ServeHTTP(0x710c60?, {0x7e4ad0?, 0xc0001340e0?}, 0xc000144000?)
        C:/Users/DexterHo/.g/go/src/net/http/server.go:2084 +0x2f
net/http.(*ServeMux).ServeHTTP(0x0?, {0x7e4ad0, 0xc0001340e0}, 0xc000140000)
        C:/Users/DexterHo/.g/go/src/net/http/server.go:2462 +0x149
net/http.serverHandler.ServeHTTP({0x7e3dd8?}, {0x7e4ad0, 0xc0001340e0}, 0xc000140000)
        C:/Users/DexterHo/.g/go/src/net/http/server.go:2916 +0x43b
net/http.(*conn).serve(0xc00005caa0, {0x7e4c78, 0xc000078f00})
        C:/Users/DexterHo/.g/go/src/net/http/server.go:1966 +0x5d7
created by net/http.(*Server).Serve
        C:/Users/DexterHo/.g/go/src/net/http/server.go:3071 +0x4db
```